### PR TITLE
Added method to change default KeyStore cache TTL

### DIFF
--- a/docs/implementation-description.md
+++ b/docs/implementation-description.md
@@ -44,7 +44,8 @@ It simply delegates the calls to another instance of [`KeyStore`](https://docs.o
 The benefit in this is that the delegate `KeyStore` can be replaced with a new instance when the underlying files have changed.
 Application or `KeyManager` does not need to be aware that the delegate instance was replaced.
 
-Since it does not make sense to check the files every time the credentials are used, at least on a busy server, there is a refresh period that sets the cap on how frequently the check happens (default `CACHE_TTL` is one second).
+Since it does not make sense to check the files every time the credentials are used, at least on a busy server, there is a refresh period that sets the cap on how frequently the check happens.
+Default cache TTL is one second.
 Once that period has expired, the modification timestamp of the files are checked by the `refresh()` method defined in the concrete subclasses.
 
 `DelegatingKeyStoreSpi` sorts the aliases returned by the delegate, allowing user to leverage the predictable ordering to select default certificate.

--- a/lib/src/main/java/fi/protonode/reloadingkeystore/DelegatingKeyStoreSpi.java
+++ b/lib/src/main/java/fi/protonode/reloadingkeystore/DelegatingKeyStoreSpi.java
@@ -53,7 +53,7 @@ public abstract class DelegatingKeyStoreSpi extends KeyStoreSpi {
     static Clock now = Clock.systemUTC();
 
     // Defines how often the delegate keystore should be checked for updates.
-    static final Duration CACHE_TTL = Duration.of(1, ChronoUnit.SECONDS);
+    static Duration cacheTtl = Duration.of(1, ChronoUnit.SECONDS);
 
     private AtomicReference<Delegate> delegate = new AtomicReference<>();
 
@@ -78,7 +78,7 @@ public abstract class DelegatingKeyStoreSpi extends KeyStoreSpi {
         }
 
         // Set the time when refresh should be checked next.
-        cacheExpiredTime = now.instant().plus(CACHE_TTL);
+        cacheExpiredTime = now.instant().plus(cacheTtl);
 
         try {
             refresh();

--- a/lib/src/main/java/fi/protonode/reloadingkeystore/PemCredentialFactory.java
+++ b/lib/src/main/java/fi/protonode/reloadingkeystore/PemCredentialFactory.java
@@ -84,7 +84,7 @@ public class PemCredentialFactory {
         // Throw exception if no PRIVATE KEY in PEM file.
         if (block == null) {
             log.error("Cannot find PRIVATE KEY PEM block in {}", path);
-            throw new IllegalArgumentException("PEM file does not have private key");
+            throw new IllegalArgumentException("PEM file does not have private key: " + path);
         }
 
         PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(block.getBytes());
@@ -100,7 +100,7 @@ public class PemCredentialFactory {
         // Throw exception if parsing failed for all algorithms.
         if (pkey == null) {
             log.error("Cannot decode private key {}", path);
-            throw new InvalidKeySpecException("Invalid private key");
+            throw new InvalidKeySpecException("Invalid private key: " + path);
         }
 
         return pkey;

--- a/lib/src/main/java/fi/protonode/reloadingkeystore/ReloadingKeyStore.java
+++ b/lib/src/main/java/fi/protonode/reloadingkeystore/ReloadingKeyStore.java
@@ -23,6 +23,7 @@ import java.security.KeyStoreSpi;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -161,11 +162,11 @@ public class ReloadingKeyStore extends KeyStore {
                 InvalidKeySpecException, IOException {
 
             if (keys.size() < certs.size()) {
-                throw new IllegalArgumentException("Missing private key");
+                throw new IllegalArgumentException("Missing private key: fewer private keys given than certificates");
             } else if (keys.size() > certs.size()) {
-                throw new IllegalArgumentException("Missing X.509 certificate");
+                throw new IllegalArgumentException("Missing X.509 certificate: fewer certs given than private keys");
             } else if (keys.isEmpty()) {
-                throw new IllegalArgumentException("No credentials configured");
+                throw new IllegalArgumentException("No credentials given: keys list was empty");
             }
 
             ReloadingPemFileKeyStoreSpi spi = new ReloadingPemFileKeyStoreSpi();
@@ -210,6 +211,17 @@ public class ReloadingKeyStore extends KeyStore {
             }
             return new Builder(new ReloadingKeyStore(spi), ReloadingPemFileKeyStoreSpi.IN_MEMORY_KEYSTORE_PASSWORD);
         }
+    }
+
+    /**
+     * Set show frequently the KeyStore(s) will check if the underlying files have changed and reload is required.
+     * The check still happens only when credentials are used. TTL of one second means that the file modification
+     * will be checked at most once per second, depending when the KeyStore is used next.
+     *
+     * @param ttl Minimum time-to-live for in-memory delegate {@code KeyStore}.
+     */
+    public static void setDefaultKeyStoreCacheTtl(Duration ttl) {
+        DelegatingKeyStoreSpi.cacheTtl = ttl;
     }
 
 }

--- a/lib/src/test/java/fi/protonode/reloadingkeystore/TestReloadingKeyStoreWithTls.java
+++ b/lib/src/test/java/fi/protonode/reloadingkeystore/TestReloadingKeyStoreWithTls.java
@@ -406,7 +406,7 @@ public class TestReloadingKeyStoreWithTls {
         // - before: keystore file were created.
         // - after: cache TTL has expired and keystore file will be checked for modification.
         Instant before = Instant.now();
-        Instant after = before.plus(DelegatingKeyStoreSpi.CACHE_TTL);
+        Instant after = before.plus(DelegatingKeyStoreSpi.cacheTtl);
 
         // Create CA and server certificate.
         Credential serverCaCreds = new Credential().subject("CN=ca");
@@ -473,7 +473,7 @@ public class TestReloadingKeyStoreWithTls {
         // - before: keystore file were created.
         // - after: cache TTL has expired and keystore file will be checked for modification.
         Instant before = Instant.now();
-        Instant after = before.plus(DelegatingKeyStoreSpi.CACHE_TTL);
+        Instant after = before.plus(DelegatingKeyStoreSpi.cacheTtl);
 
         // Create CA and server certificate.
         log.debug("Writing initial PEM files: {}, {}", serverCertPem, serverKeyPem);


### PR DESCRIPTION
Added static method ReloadingKeyStore.setDefaultKeyStoreCacheTtl() to allow changing the default 1 second delegate KeyStore cache TTL.

Added path information to exceptions thrown at PEM load failures.

Closes #2 
Closes #3 